### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   cleanup:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - name: Cleanup


### PR DESCRIPTION
Potential fix for [https://github.com/cjmalloy/jasper-ui/security/code-scanning/11](https://github.com/cjmalloy/jasper-ui/security/code-scanning/11)

To fix the issue, we will add a `permissions` block to the workflow. Based on the commands used in the workflow, the `contents: read` permission is required to fetch repository data, and the `actions: write` permission is needed to delete caches. These permissions will be explicitly defined at the job level to ensure the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
