### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Draft GitHub Release
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cjmalloy/jasper-ui/security/code-scanning/12](https://github.com/cjmalloy/jasper-ui/security/code-scanning/12)

To fix the problem, explicitly set the `permissions` key at the workflow or job level to grant only the minimum required privileges. In this workflow, the steps that require elevated permissions are the creation of a release and the upload of release assets, which require `contents: write`. The rest of the workflow does not require additional permissions. The best way to fix this is to add a `permissions` block at the top level of the workflow (applies to all jobs), or at the job level if you want to be more granular. In this case, adding at the workflow level is sufficient and clear. Insert the following at the top of the file, after the `name` field and before `on`:

```yaml
permissions:
  contents: write
```

No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
