### PR TITLE
Filename hint breaks cache for thumbnails

### DIFF
--- a/src/app/component/map/map.component.ts
+++ b/src/app/component/map/map.component.ts
@@ -213,7 +213,7 @@ export class MapComponent implements OnChanges, OnDestroy, HasChanges {
     if (thumbnailPlugin.url) {
       const isProxy = this.admin.getPlugin('plugin/thumbnail')?.config?.proxy;
       const url = isProxy
-        ? this.proxy.getFetch(thumbnailPlugin.url, ref.origin, ref.title || 'thumbnail', true)
+        ? this.proxy.getFetch(thumbnailPlugin.url, ref.origin, 'thumbnail', true)
         : thumbnailPlugin.url;
       el.style.backgroundImage = `url(${url})`;
     }

--- a/src/app/component/ref/ref.component.ts
+++ b/src/app/component/ref/ref.component.ts
@@ -437,9 +437,7 @@ export class RefComponent implements OnChanges, AfterViewInit, OnDestroy, HasCha
     const rawUrl = String(sb.url);
     const origin = this.ref?.origin || this.repostRef?.origin || '';
     if (rawUrl.startsWith('cache:') || this.admin.getPlugin('plugin/thumbnail')?.config?.proxy) {
-      const ext = getExtension(rawUrl) || '';
-      const title = this.ref?.title || 'storyboard';
-      return this.proxy.getFetch(rawUrl, origin, title + (title.endsWith(ext) ? '' : ext));
+      return this.proxy.getFetch(rawUrl, origin, 'storyboard');
     } else {
       return rawUrl;
     }

--- a/src/app/pipe/thumbnail.pipe.ts
+++ b/src/app/pipe/thumbnail.pipe.ts
@@ -4,7 +4,6 @@ import { Ref } from '../model/ref';
 import { AdminService } from '../service/admin.service';
 import { ProxyService } from '../service/api/proxy.service';
 import { OembedStore } from '../store/oembed';
-import { getExtension } from '../util/http';
 import { hasTag } from '../util/tag';
 
 @Pipe({
@@ -23,13 +22,13 @@ export class ThumbnailPipe implements PipeTransform {
     for (const ref of refs) {
       if (!ref) continue;
       for (const plugin of ['plugin/thumbnail', 'plugin/image', 'plugin/video']) {
-        if (refUrl(ref, plugin)) return of(this.fetchUrl(refUrl(ref, plugin), ref.origin, ref.title || plugin.substring('plugin/'.length), plugin));
+        if (refUrl(ref, plugin)) return of(this.fetchUrl(refUrl(ref, plugin), ref.origin, plugin));
       }
       if (hasTag('plugin/embed', ref)) {
         return this.store.get(ref.plugins?.['plugin/embed']?.url || ref.url).pipe(
           map(oembed => {
             if (oembed?.thumbnail_url) {
-              return this.fetchUrl(oembed.thumbnail_url, ref.origin, ref.title || oembed.title || 'thumbnail', 'plugin/thumbnail');
+              return this.fetchUrl(oembed.thumbnail_url, ref.origin, 'plugin/thumbnail');
             }
             return '';
           }),
@@ -38,23 +37,22 @@ export class ThumbnailPipe implements PipeTransform {
       if (!this.validUrl(ref.url)) continue;
       const embedPlugins = this.admin.getEmbeds(ref);
       for (const plugin of ['plugin/image', 'plugin/video']) {
-        if (embedPlugins.includes(plugin)) return of(this.fetchUrl(ref.url, ref.origin, ref.title || plugin.substring('plugin/'.length), plugin));
+        if (embedPlugins.includes(plugin)) return of(this.fetchUrl(ref.url, ref.origin, plugin));
       }
     }
     if (force) {
       for (const ref of refs) {
         if (!this.validUrl(ref?.url)) continue;
-        return of(this.fetchUrl(ref!.url, ref!.origin, ref?.title || 'image', 'plugin/image'));
+        return of(this.fetchUrl(ref!.url, ref!.origin, 'plugin/image'));
       }
     }
     return of('');
   }
 
-  fetchUrl(url: string, origin: string | undefined, title: string, plugin: string) {
+  fetchUrl(url: string, origin: string | undefined, plugin: string) {
     if (!url) return '';
     if (url.startsWith('cache:') || this.admin.getPlugin(plugin)?.config?.proxy) {
-      const ext = getExtension(url) || '';
-      return this.proxy.getFetch(url, origin, title + (title.endsWith(ext) ? '' : ext), true);
+      return this.proxy.getFetch(url, origin, 'thumbnail', true);
     }
     return url;
   }

--- a/src/app/service/api/proxy.service.ts
+++ b/src/app/service/api/proxy.service.ts
@@ -58,7 +58,7 @@ export class ProxyService {
 
   fetch(url: string, origin = '', filename = 'file', thumbnail?: boolean): Observable<Resource> {
     this.cacheList.add(origin + url);
-    return this.http.get(`${this.base}/${sanitizePath(filename)}`, {
+    return this.http.get(thumbnail ? this.base : `${this.base}/${sanitizePath(filename)}`, {
       params: params({ url, origin, thumbnail }),
       observe: 'response',
       responseType: 'arraybuffer',
@@ -92,7 +92,7 @@ export class ProxyService {
     if (!url) return '';
     if (url.startsWith('data:')) return url;
     if (this.config.prefetch && this.store.account.user) this.prefetch(url, origin, filename);
-    if (thumbnail) return `${this.base}/${sanitizePath(filename.trim())}?thumbnail=true&url=${encodeURIComponent(url)}&origin=${origin}`;
+    if (thumbnail) return `${this.base}?thumbnail=true&url=${encodeURIComponent(url)}&origin=${origin}`;
     return `${this.base}/${sanitizePath(filename.trim())}?url=${encodeURIComponent(url)}&origin=${origin}`;
   }
 


### PR DESCRIPTION
The filename hint is only useful for downloaded media.